### PR TITLE
Added support for plain objects with keys with value undefined

### DIFF
--- a/lib/fromJson.js
+++ b/lib/fromJson.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var types = require('./types');
+var undefinedConst = require('./undefined');
 var VirtualNode = require('virtual-dom/vnode/vnode');
 var VirtualText = require('virtual-dom/vnode/vtext');
 var VirtualPatch = require('virtual-dom/vnode/vpatch');
@@ -23,6 +24,9 @@ function plainObjectFromJson(json) {
   /* this is fine; these objects are always plain */
   for (var key in json) {
     var val = json[key];
+    if(val === undefinedConst) {
+      val = undefined;
+    }
     res[key] = typeof val !== 'undefined' ? fromJson(val) : val;
   }
   return res;

--- a/lib/toJson.js
+++ b/lib/toJson.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var types = require('./types');
+var undefinedConst = require('./undefined');
 
 var SoftSetHook =
   require('virtual-dom/virtual-hyperscript/hooks/soft-set-hook');
@@ -21,7 +22,7 @@ function plainObjectToJson(obj) {
   /* this is fine; these objects are always plain */
   for (var key in obj) {
     var val = obj[key];
-    res[key] = typeof val !== 'undefined' ? toJson(val) : val;
+    res[key] = typeof val !== 'undefined' ? toJson(val) : undefinedConst;
   }
   return res;
 }

--- a/lib/undefined.js
+++ b/lib/undefined.js
@@ -1,0 +1,4 @@
+//Magic value to map keys with a value of undefined to in JSON form since JSON
+//won't preserve those.  This is necessary because in patches, the removal of 
+//a property is represented by the property name mapped to undefined
+module.exports = "____UnDeFiNeD____"; 

--- a/test/test.js
+++ b/test/test.js
@@ -51,6 +51,18 @@ describe('vdom-to-json test suite', function () {
     json1.should.deep.equal(json2);
   });
 
+  it('should preserve keys with undefined values for patch property removal', function(){
+    var simpleObj= {
+      k1: 'fred',
+      k2: undefined
+    };
+    var deserialized = fromJson(JSON.parse(JSON.stringify(toJson(simpleObj))));
+    Object.keys(deserialized).length.should.equal(2);
+    deserialized['k1'].should.equal('fred');
+    ('k2' in deserialized).should.equal(true);
+    (deserialized['k2'] === undefined).should.equal(true);
+  });
+
   var structures = [
     h("div", "hello"),
     h("div", [h("span", "goodbye")]),


### PR DESCRIPTION
JSON.stringify leaves keys with a value of undefined out, so have to replace this with a magic value.  

Supporting this is necessary because the VirtualPatch object represents removed properties of a VirtualNode as a plain object with the property name as a key and a value of undefined.  So need to preserve this through a JSON.stringify and JSON.parse round trip.