### PR TITLE
Avoid repeated tree serialization

### DIFF
--- a/lib/fromJson.js
+++ b/lib/fromJson.js
@@ -8,17 +8,17 @@ var VirtualPatch = require('virtual-dom/vnode/vpatch');
 var SoftSetHook =
   require('virtual-dom/virtual-hyperscript/hooks/soft-set-hook');
 
-function arrayFromJson(json) {
+function arrayFromJson(json, ctx) {
   var len = json.length;
   var i = -1;
   var res = new Array(len);
   while (++i < len) {
-    res[i] = fromJson(json[i]);
+    res[i] = fromJson(json[i], ctx);
   }
   return res;
 }
 
-function plainObjectFromJson(json) {
+function plainObjectFromJson(json, ctx) {
   var res = {};
   /* jshint -W089 */
   /* this is fine; these objects are always plain */
@@ -27,50 +27,58 @@ function plainObjectFromJson(json) {
     if(val === undefinedConst) {
       val = undefined;
     }
-    res[key] = typeof val !== 'undefined' ? fromJson(val) : val;
+    res[key] = typeof val !== 'undefined' ? fromJson(val, ctx) : val;
   }
   return res;
 }
 
-function virtualNodeFromJson(json) {
+function virtualNodeFromJson(json, ctx) {
   return new VirtualNode(json.tn,
-    json.p ? plainObjectFromJson(json.p) : {}, // patch
-    json.c ? arrayFromJson(json.c) : [], // children
+    json.p ? plainObjectFromJson(json.p, ctx) : {}, // patch
+    json.c ? arrayFromJson(json.c, ctx) : [], // children
     json.k, // key
     json.n); // namespace
 }
 
-function virtualTextFromJson(json) {
+function virtualTextFromJson(json, ctx) {
   return new VirtualText(json.x);
 }
 
-function virtualPatchFromJson(json) {
+function virtualPatchFromJson(json, ctx) {
+  var vNode = null;
+  if(typeof(json.v) === 'string' && json.v.indexOf('i:') === 0) {
+    var idx = parseInt(json.v.substr(2));
+    vNode = ctx.dftIndexArray[idx]; //look up this index from the dft index
+  } else {
+    vNode = json.v ? fromJson(json.v, ctx) : null; // virtualNode;
+  }
+
   return new VirtualPatch(
     json.pt, // patchType
-    json.v ? fromJson(json.v) : null, // virtualNode
-    json.p && fromJson(json.p) // patch
+    vNode,
+    json.p && fromJson(json.p, ctx) // patch
   );
 }
 
-function softSetHookFromJson(json) {
+function softSetHookFromJson(json, ctx) {
   return new SoftSetHook(json.value);
 }
 
-function objectFromJson(json) {
+function objectFromJson(json, ctx) {
   switch (json.t) { // type
     case types.VirtualPatch:
-      return virtualPatchFromJson(json);
+      return virtualPatchFromJson(json, ctx);
     case types.VirtualNode:
-      return virtualNodeFromJson(json);
+      return virtualNodeFromJson(json, ctx);
     case types.VirtualTree:
-      return virtualTextFromJson(json);
+      return virtualTextFromJson(json, ctx);
     case types.SoftSetHook:
-      return softSetHookFromJson(json);
+      return softSetHookFromJson(json, ctx);
   }
-  return plainObjectFromJson(json);
+  return plainObjectFromJson(json, ctx);
 }
 
-function fromJson(json) {
+function fromJson(json, ctx) {
   var type = typeof json;
 
   switch (type) {
@@ -83,14 +91,35 @@ function fromJson(json) {
   // type === 'object'
 
   if (Array.isArray(json)) {
-    return arrayFromJson(json);
+    return arrayFromJson(json, ctx);
   }
 
   if (!json) { // null
     return null;
   }
 
-  return objectFromJson(json);
+  if(json && json['a'] && json['a'].tn && ctx == null) {
+    ctx = {diffRoot: virtualNodeFromJson(json['a'])};
+    ctx.dftIndexArray = indexRoot(ctx.diffRoot);
+  }
+
+  return objectFromJson(json, ctx);
+}
+
+function indexRoot(root) {
+  var idxArray = [];
+  indexNode(idxArray, root, 0);
+  return idxArray;
+}
+
+function indexNode(idxArray, node, idx) {
+  idxArray[idx] = node;
+  if(node.children) {
+    node.children.forEach(function(childNode) {
+      idx = indexNode(idxArray, childNode, ++idx);
+    });
+  }
+  return idx;
 }
 
 module.exports = fromJson;

--- a/lib/toJson.js
+++ b/lib/toJson.js
@@ -6,38 +6,49 @@ var undefinedConst = require('./undefined');
 var SoftSetHook =
   require('virtual-dom/virtual-hyperscript/hooks/soft-set-hook');
 
-function arrayToJson(arr) {
+function arrayToJson(arr, ctx) {
   var len = arr.length;
   var i = -1;
   var res = new Array(len);
   while (++i < len) {
-    res[i] = toJson(arr[i]);
+    res[i] = toJson(arr[i], ctx);
   }
   return res;
 }
 
-function plainObjectToJson(obj) {
+function plainObjectToJson(obj, ctx) {
   var res = {};
+  var trackPatchIndex = false;
+  var childCtx = ctx;
+  if(obj && obj['a'] && obj['a'].tagName) {
+    childCtx = cloneObj({}, ctx); //clone ctx
+    trackPatchIndex = true;
+  }
+  //childCtx['patchHashIndex'] = null;
+
   /* jshint -W089 */
   /* this is fine; these objects are always plain */
   for (var key in obj) {
     var val = obj[key];
-    res[key] = typeof val !== 'undefined' ? toJson(val) : undefinedConst;
+    if(trackPatchIndex) {
+      childCtx['patchHashIndex'] = parseInt(key);
+    }
+    res[key] = typeof val !== 'undefined' ? toJson(val, childCtx) : undefinedConst;
   }
   return res;
 }
 
-function virtualNodeToJson(obj) {
+function virtualNodeToJson(obj, ctx) {
   var res = {
     // type
     t: types.VirtualNode,
     tn: obj.tagName
   };
   if (Object.keys(obj.properties).length) {
-    res.p = plainObjectToJson(obj.properties);
+    res.p = plainObjectToJson(obj.properties, ctx);
   }
   if (obj.children.length) {
-    res.c = arrayToJson(obj.children);
+    res.c = arrayToJson(obj.children, ctx);
   }
   if (obj.key) {
     res.k = obj.key;
@@ -48,7 +59,7 @@ function virtualNodeToJson(obj) {
   return res;
 }
 
-function virtualTextToJson(obj) {
+function virtualTextToJson(obj, ctx) {
   return {
     // type
     t: types.VirtualTree,
@@ -57,7 +68,7 @@ function virtualTextToJson(obj) {
   };
 }
 
-function virtualPatchToJson(obj) {
+function virtualPatchToJson(obj, ctx) {
   var res = {
     // type
     t: types.VirtualPatch,
@@ -66,17 +77,25 @@ function virtualPatchToJson(obj) {
   };
 
   if (obj.vNode) {
-    res.v = toJson(obj.vNode);
+    if(ctx && ctx.patchHashIndex != null) {
+      //if the context contains the index (from the key in the hash) for this
+      //patch, use it as a string key for this value so we can just reference
+      //that point in the root tree instead of serializing same content over
+      //again
+      res.v = "i:"+ctx.patchHashIndex;
+    } else {
+      res.v = toJson(obj.vNode, ctx);
+    }
   }
 
   if (obj.patch) {
-    res.p = toJson(obj.patch);
+    res.p = toJson(obj.patch, ctx);
   }
 
   return res;
 }
 
-function softSetHookToJson(obj) {
+function softSetHookToJson(obj, ctx) {
   return {
     // type
     t: types.SoftSetHook,
@@ -84,25 +103,25 @@ function softSetHookToJson(obj) {
   };
 }
 
-function objectToJson(obj) {
+function objectToJson(obj, ctx) {
   if ('patch' in obj && typeof obj.type === 'number') {
-    return virtualPatchToJson(obj);
+    return virtualPatchToJson(obj, ctx);
   }
   if (obj.type === 'VirtualNode') {
-    return virtualNodeToJson(obj);
+    return virtualNodeToJson(obj, ctx);
   }
   if (obj.type === 'VirtualText') {
-    return virtualTextToJson(obj);
+    return virtualTextToJson(obj, ctx);
   }
   if (obj instanceof SoftSetHook) {
-    return softSetHookToJson(obj);
+    return softSetHookToJson(obj, ctx);
   }
 
   // plain object
-  return plainObjectToJson(obj);
+  return plainObjectToJson(obj, ctx);
 }
 
-function toJson(obj) {
+function toJson(obj, ctx) {
 
   var type = typeof obj;
 
@@ -115,14 +134,32 @@ function toJson(obj) {
 
   // type === 'object'
   if (Array.isArray(obj)) {
-    return arrayToJson(obj);
+    return arrayToJson(obj, ctx || {});
   }
 
   if (!obj) { // null
     return null;
   }
 
-  return objectToJson(obj);
+  //If we enter with a null context and we've got an object with an 'a'
+  //property with an object with tag name then it's likely we have a
+  //patchset object and the a is the original root of the diff tree
+  if(obj && obj['a'] && obj['a'].tagName && !ctx) {
+    ctx = {diffRoot: obj['a']};
+  } else if(ctx == null) {
+    ctx = {};
+  }
+
+  return objectToJson(obj, ctx);
+}
+
+//PhantomJS doesn't support Object.assigns, so just implement a clone
+//method here.
+function cloneObj(a,b) {
+  Object.keys(b).forEach(function(k) {
+    a[k] = b[k];
+  });
+  return a;
 }
 
 module.exports = toJson;

--- a/lib/toJson.js
+++ b/lib/toJson.js
@@ -33,7 +33,8 @@ function plainObjectToJson(obj, ctx) {
     if(trackPatchIndex) {
       childCtx['patchHashIndex'] = parseInt(key);
     }
-    res[key] = typeof val !== 'undefined' ? toJson(val, childCtx) : undefinedConst;
+    res[key] = typeof val !== 'undefined' ?
+        toJson(val, childCtx) : undefinedConst;
   }
   return res;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -63,6 +63,29 @@ describe('vdom-to-json test suite', function () {
     (deserialized['k2'] === undefined).should.equal(true);
   });
 
+  describe('serialization of virtualNodes in patches as references to a tree',
+  function(){
+    it('should use references for vNodes in json version of patches',
+        function () {
+      var nodeA = renderCount(0);
+      var nodeB = renderCount(1);
+      var patch1 = diff(nodeA, nodeB);
+      var json1 = toJson(patch1);
+      json1['0'].v.should.equal('i:0');
+      json1['1'].v.should.equal('i:1');
+    });
+    it('should properly restore the vnode references in the patch', function(){
+      var nodeA = renderCount(0);
+      var nodeB = renderCount(1);
+      var patch1 = diff(nodeA, nodeB);
+      var json1 = toJson(patch1);
+      var patch2 = fromJson(json1);
+      patch2['0'].vNode.should.deep.equal(patch2['a']);
+      patch2['1'].vNode.should.deep.equal(patch2['a'].children[0]);
+    });
+  });
+
+
   var structures = [
     h("div", "hello"),
     h("div", [h("span", "goodbye")]),

--- a/test/test.js
+++ b/test/test.js
@@ -51,7 +51,8 @@ describe('vdom-to-json test suite', function () {
     json1.should.deep.equal(json2);
   });
 
-  it('should preserve keys with undefined values for patch property removal', function(){
+  it('should preserve keys with undefined values for patch property removal',
+      function () {
     var simpleObj= {
       k1: 'fred',
       k2: undefined
@@ -74,7 +75,7 @@ describe('vdom-to-json test suite', function () {
       json1['0'].v.should.equal('i:0');
       json1['1'].v.should.equal('i:1');
     });
-    it('should properly restore the vnode references in the patch', function(){
+    it('should restore the vnode references in the patch', function () {
       var nodeA = renderCount(0);
       var nodeB = renderCount(1);
       var patch1 = diff(nodeA, nodeB);
@@ -83,6 +84,36 @@ describe('vdom-to-json test suite', function () {
       patch2['0'].vNode.should.deep.equal(patch2['a']);
       patch2['1'].vNode.should.deep.equal(patch2['a'].children[0]);
     });
+    it('should handle fromJson of legacy patches with serialized vnode ' +
+        'instead of indexed reference', function () {
+      var nodeA = renderCount(0);
+      var nodeB = renderCount(1);
+      var patch1 = diff(nodeA, nodeB);
+      var json1 = toJson(patch1);
+      json1['0'].v = json1['a'];
+      json1['1'].v = json1['a'].c[0];
+      var patch2 = fromJson(json1);
+      patch2['0'].vNode.should.deep.equal(patch2['a']);
+      patch2['1'].vNode.should.deep.equal(patch2['a'].children[0]);
+    });
+    it('should be able to serialize part of a patch without ' +
+        'ctx.patchHashIndex', function () {
+      var nodeA = renderCount(0);
+      var nodeB = renderCount(1);
+      var patch1 = diff(nodeA, nodeB);
+      //call toJson on one of the patches - this won't provide the ctx
+      //This test is needed to get code coverage
+      var json1 = toJson(patch1['0']);
+      json1.v.should.exist;
+    });
+  });
+  it('should toJson on array without a provided context', function () {
+    var nodeA = renderCount(0);
+    var nodeB = renderCount(1);
+    var patch1 = diff(nodeA, nodeB);
+    var json1 = toJson([patch1]);
+    json1[0]["0"].v.should.exist;
+    json1[0]["0"].p.should.exist;
   });
 
 


### PR DESCRIPTION
Caveat: I'm new to this library and the virtual-dom library, so might have missed something, but I think this is useful.

For my application, I'm going to be storing the json serialized diffs.  When serializing a diff in JSON format, the full starting dom is included as "a" in the hash of the diff.  Each VirtualPatch item has a reference to this tree called vNode (becomes v after transformation by this library).  Serializing this portion of the tree is redundant since it's already included in this "a" key.  This results in a lot of extra storage usage and extra serialization work.

This patch replaces the contents of the v key in the serialized format with a string of the form "i:<index num>" where "index num" is the same number used in as the key for the VirtualPatch in the diff hash (which appears to be the index into a depth first traversal of the full dom tree).  

When deserializing, the "a" key is processed and a depth first traversal builds an array of the index numbers to the nodes in the tree.  Then when processing the VirtualPatchS the v key is checked to see if it's a string starting with "i:" and if so, we look up the node for that index number and use that for vNode in the deserialized object.

To do this, I've added an optional ctx parameter to the toJson and fromJson.  If not provided, it will be created.  If ctx is being created and the object is a hash, it will test to see if it looks like a "diff" object and add the appropriate context parameters.  

Please let me know if I've overlooked or misunderstood anything or you see any improvements that should be made.